### PR TITLE
ImportError: No module named parse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,9 @@ setup(
     zip_safe=False,
     install_requires=[
         "senaite.lims>=2.0.0rc1",
-        "mysql-connector-python",
+        # mysql-connector-python >= 8.0.24 does not support Python 2.x anymore
+        # https://dev.mysql.com/doc/relnotes/connector-python/en/news-8-0-24.html
+        "mysql-connector-python<8.0.24",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

mysql-connector-python >= 8.0.24 does not support Python 2.x anymore
https://dev.mysql.com/doc/relnotes/connector-python/en/news-8-0-24.html

## Current behavior before PR

An `ImportError: No module named parse` arises

## Desired behavior after PR is merged

No error arises

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
